### PR TITLE
Replace book index with placeholder description

### DIFF
--- a/book/index.md
+++ b/book/index.md
@@ -1,19 +1,4 @@
 (index)=
-# Calculus 5
+# Calculus
 
-::::{question} Short-answer blocks
-:type: short-answer
-:variant: blocks
-:showanswer:
-Fill in the correct answer in the input fields.
----
-T[TeachBooks] The correct answer is _TeachBooks_:
-= Perfect!
-> Did you make a typo? Try again. Remember that the answer is case-sensitive.
-& Hint: The answer is the name of the organisation that created this book, and it starts with a capital T.
-
-MR[0<x<=1] The correct answer is a number between 0 and 1, but not including 0:
-& Hint: The answer is a number, so it cannot be negative and cannot be larger than 1.
----
-What do you think?
-::::
+This is a book about calculus. More information to come.


### PR DESCRIPTION
Replace the previous index contents with a brief placeholder. The heading was changed from "Calculus 5" to "Calculus" and the short-answer interactive blocks were removed, leaving a single introductory line while the book content is developed.