### PR TITLE
Add algebraic sum identity and update math ext

### DIFF
--- a/book/Algebra/Numbers_and_coordinate_systems/sums_and_products.md
+++ b/book/Algebra/Numbers_and_coordinate_systems/sums_and_products.md
@@ -489,6 +489,60 @@ $$
 
 ::::::
 
+We finish this section with a very useful result that is often used:
+
+:::{prf:theorem}
+:label: Thm:SumsAndProducts:MagicRule
+
+Assume $a$ and $b$ are real numbers and $n$ is an integer. Then we have
+
+$$
+(a-b)\sum_{k=1}^{n}a^{n-k}b^{k-1}=a^n-b^n.
+$$
+
+:::
+
+:::{admonition} Proof of {prf:ref}`Thm:SumsAndProducts:MagicRule`
+:class: tudproof, dropdown
+
+We prove the theorem by induction on $n$.
+
+For $n=1$ we have on the left-hand side that
+
+$$
+(a-b)\sum_{k=1}^{1}a^{1-k}b^{k-1} = (a-b)a^{1-1}b^{1-1} = a-b,
+$$
+
+and on the right-hand side that
+
+$$
+a^1-b^1 = a-b,
+$$
+
+so the statement holds for $n=1$.
+
+Now assume that the statement holds for certain value of $n=N$, so
+
+$$
+(a-b)\sum_{k=1}^{N}a^{N-k}b^{k-1}=a^N-b^N.
+$$
+
+ then we have for $n=N+1$ that
+
+\begin{align*}
+(a-b)\sum_{k=1}^{N+1}a^{N+1-k}b^{k-1}&=(a-b)\left(\sum_{k=1}^{N}a^{N+1-k}b^{k-1}+a^{N+1-(N+1)}b^{(N+1)-1}\right) \\
+&=(a-b)\left(a\sum_{k=1}^{N}a^{N-k}b^{k-1}+b^N\right) \\
+&=(a-b)a\sum_{k=1}^{N}a^{N-k}b^{k-1}+(a-b)b^N \\
+&=a(a-b)\sum_{k=1}^{N}a^{N-k}b^{k-1}+(a-b)b^N \\
+&=a\left(a^N-b^N\right)+(a-b)b^N \\
+&=a^{N+1}-ab^N+ab^N-b^{N+1} \\
+&=a^{N+1}-b^{N+1}.
+\end{align*}
+
+This proves the statement for all $n\in\{1,2,3,\ldots\}$.
+
+:::
+
 With this we end our treatment of finite sums.
 
 ## Finite products

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -29,7 +29,7 @@ sphinx:
     # image_checker: _ext/
     numref_section: _ext/
     repeat: _ext/
-    math_punctuation_into_text: _ext/
+    # math_punctuation_into_text: _ext/
   config:
     # prime_applets_base_url: "http://localhost:5173/applet/"
     # prime_applets_base_url: "https://deploy-preview-432--openla-preview.netlify.app/applet/"

--- a/book/_ext/math_punctuation_into_text.py
+++ b/book/_ext/math_punctuation_into_text.py
@@ -1,8 +1,8 @@
 from docutils import nodes
 from sphinx.transforms import SphinxTransform
 
-# from sphinx.util import logging
-# logger = logging.getLogger(__name__)
+from sphinx.util import logging
+logger = logging.getLogger(__name__)
 
 PUNCTUATION = {".", ",", ";", ":", "!", "?"}
 
@@ -14,7 +14,7 @@ class InlineMathPunctuationIntoText(SphinxTransform):
     default_priority = 700  # After parsing, before writing
 
     def apply(self):
-        for parent in self.document.traverse(nodes.Element):
+        for parent in self.document.findall(nodes.Element):
             i = 0
             while i < len(parent.children) - 1:
                 left = parent.children[i]
@@ -26,6 +26,11 @@ class InlineMathPunctuationIntoText(SphinxTransform):
                     and right.strip() in PUNCTUATION
                 ):
                     punct = right.strip()
+
+                    logger.info(f"Found punctuation '{punct}' after inline math at line {left.line} in {left.parent}.", color="fuchsia")
+
+                    if len(punct) > 1:
+                        raise ValueError(f"Unexpected long punctuation: '{punct}'")
 
                     # Modify math content
                     left.astext()  # ensure node initialized


### PR DESCRIPTION
Add a new theorem (MagicRule) and induction proof to sums_and_products.md establishing (a-b) sum_{k=1..n} a^{n-k} b^{k-1} = a^n - b^n. Comment out the math_punctuation_into_text extension in _config.yml. Update _ext/math_punctuation_into_text.py to enable logging, switch from document.traverse to document.findall, log found punctuation with location info, and add a guard that raises on unexpected multi-character punctuation before injecting \text{...} into inline math.