### PR TITLE
Enable theorem/term indexing; bump dependency

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -65,6 +65,7 @@ sphinx:
       date:
         substitute_missing: true
     sphinx_indexed_defs_indexed_nodes: ['strong']
+    sphinx_indexed_defs_index_theorems_terms: true
     tud_change_titlesize: true
     new_tab_link_show_external_link_icon: true
     visualized_auto_cluster: true

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -30,6 +30,8 @@ sphinx:
     numref_section: _ext/
     math_punctuation: _ext/
   config:
+    patch_config:
+      disabled-patches: ["hash"]
     # prime_applets_base_url: "http://localhost:5173/applet/"
     # prime_applets_base_url: "https://deploy-preview-456--openla-preview.netlify.app/applet/"
     sticky_margin:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ teachbooks == 0.2.4 # depends on jupyter-book
 sphinx-tudelft-theme == 1.2.2
 teachbooks-sphinx-grasple == 1.3.0
 sphinx-prime-applets == 1.3.1
-sphinx-indexed-definitions == 1.1.0
+sphinx-indexed-definitions == 1.2.0
 # sphinx-ref-graph == 1.0.2
 sphinx-new-tab-link == 0.8.1
 sphinx-apa-references == 1.0


### PR DESCRIPTION
Enable sphinx-indexed-definitions to index theorems and terms by setting sphinx_indexed_defs_index_theorems_terms: true in book/_config.yml, and update requirements.txt to use sphinx-indexed-definitions 1.2.0 to match the new feature/fix.